### PR TITLE
Lhofmann/fix jenkinsjob

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,15 @@
 # Docker image for running https://github.com/phacility/phabricator
 #
 
-FROM    debian:wheezy-slim
+FROM    debian:jessie
 MAINTAINER  Yvonnick Esnault <yvonnick@esnau.lt>
 
 ENV DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
 
 # TODO: review this dependency list
-RUN     apt-get clean && apt-get update && apt-get install -y \
+RUN     apt-get clean
+RUN	apt-get update
+RUN 	apt-get install -y \
 	        git \
             apache2 \
             curl \
@@ -29,8 +31,8 @@ RUN     apt-get clean && apt-get update && apt-get install -y \
             sendmail \
             subversion \
             tar \
-            sudo \
-        && apt-get clean && rm -rf /var/lib/apt/lists/*
+            sudo 
+RUN	    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # For some reason phabricator doesn't have tagged releases. To support
 # repeatable builds use the latest SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ MAINTAINER  Yvonnick Esnault <yvonnick@esnau.lt>
 ENV DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
 
 # TODO: review this dependency list
-RUN     apt-get clean
-RUN	apt-get update
+RUN     apt-get update
 RUN 	apt-get install -y \
 	        git \
             apache2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Docker image for running https://github.com/phacility/phabricator
 #
 
-FROM    debian:jessie
+FROM    debian:wheezy-slim
 MAINTAINER  Yvonnick Esnault <yvonnick@esnau.lt>
 
 ENV DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true


### PR DESCRIPTION
fixing the devops-phabricator jenkins job by taking out the apt-get clean command.